### PR TITLE
Support SQLite for local/self-contained dev setups

### DIFF
--- a/backend/alembic/versions/0003_fk_on_delete_cascade.py
+++ b/backend/alembic/versions/0003_fk_on_delete_cascade.py
@@ -36,6 +36,12 @@ _FKS = [
 
 
 def upgrade() -> None:
+    # SQLite's unnamed FKs (created via plain sa.ForeignKey) aren't reachable by
+    # name through batch mode, and the ORM's delete-orphan cascades already give
+    # SQLite the same behavior at the application level — so this migration is a
+    # Postgres-only DDL change.
+    if op.get_bind().dialect.name == "sqlite":
+        return
     for table, constraint, column, ref_table in _FKS:
         op.drop_constraint(constraint, table, type_="foreignkey")
         op.create_foreign_key(
@@ -44,6 +50,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    if op.get_bind().dialect.name == "sqlite":
+        return
     for table, constraint, column, ref_table in _FKS:
         op.drop_constraint(constraint, table, type_="foreignkey")
         op.create_foreign_key(constraint, table, ref_table, [column], ["id"])

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -3,14 +3,14 @@ from sqlalchemy.orm import declarative_base
 
 from app.config import settings
 
-# Create async engine
-engine = create_async_engine(
-    settings.DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://"),
-    echo=settings.DEBUG,
-    pool_pre_ping=True,
-    pool_size=10,
-    max_overflow=20,
-)
+# Create async engine. SQLite (NullPool) doesn't accept pool_size/max_overflow,
+# which only apply to server-based DBs like Postgres.
+_db_url = settings.DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://")
+_engine_kwargs = {"echo": settings.DEBUG, "pool_pre_ping": True}
+if not _db_url.startswith("sqlite"):
+    _engine_kwargs.update(pool_size=10, max_overflow=20)
+
+engine = create_async_engine(_db_url, **_engine_kwargs)
 
 # Create session factory
 AsyncSessionLocal = async_sessionmaker(


### PR DESCRIPTION
## Summary
- `database.py`: skip Postgres-only `pool_size`/`max_overflow` kwargs when `DATABASE_URL` is SQLite — SQLite uses `NullPool`, which doesn't accept those arguments, so `create_async_engine` raised a `TypeError` on startup.
- `0003_fk_on_delete_cascade.py`: skip this migration's FK rewrite on SQLite. SQLite's unnamed foreign keys (from plain `sa.ForeignKey`) can't be targeted by name through Alembic batch mode, and the ORM's `delete-orphan` cascades (noted in the migration's own docstring) already give SQLite equivalent cascade behavior — so this is a Postgres-only DDL change.

## Why
Got the project running fully self-contained on a local Windows box (embedded Python, portable Redis, no Docker/Postgres/AWS) using SQLite in place of Postgres for simplicity. The app already defaults to local storage and has no Postgres-specific schema types, so SQLite is a viable lightweight local-dev backend — these two fixes were the only blockers to `alembic upgrade head` and app startup succeeding against SQLite.

## Test plan
- [x] `alembic upgrade head` runs clean against a fresh SQLite DB (0000 -> 0003)
- [x] Backend starts and `/health` reports `"database": "connected"`
- [x] Existing Postgres path is unaffected (kwargs/migration only change behavior when dialect is sqlite)