### PR TITLE
Fix MuseTalk worker startup deadlock; harden video playback, TTS init & hydration

### DIFF
--- a/backend/app/services/animator.py
+++ b/backend/app/services/animator.py
@@ -38,6 +38,7 @@ class AvatarAnimator:
         self._worker_proc: Optional[asyncio.subprocess.Process] = None
         self._worker_lock = asyncio.Lock()
         self._worker_env: dict = {}
+        self._worker_stderr_path: Optional[Path] = None
 
         if self.device == "cuda":
             gpu_name = torch.cuda.get_device_name(0)
@@ -130,15 +131,25 @@ class AvatarAnimator:
         worker_script = self._resolve_worker_script(musetalk_dir)
 
         logger.info("Starting persistent MuseTalk worker (loading models once)…")
+        # stderr -> a file, NOT a pipe. The worker's model loading (tqdm progress,
+        # HF "Loading weights" bars, library warnings) writes a lot of stderr
+        # output; with stderr=PIPE and nobody ever draining it, the OS pipe
+        # buffer (~64KB on Windows) fills up and the worker process BLOCKS on
+        # its next stderr write — indefinitely, since nothing reads it. That
+        # looked like "loading is just slow" but was actually a silent deadlock
+        # that always ended in a timeout. File writes never block on a reader.
+        self._worker_stderr_path = musetalk_dir / "worker_stderr.log"
+        stderr_file = open(self._worker_stderr_path, "ab")
         proc = await asyncio.create_subprocess_exec(
             sys.executable,
             str(worker_script),
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+            stderr=stderr_file,
             cwd=str(musetalk_dir),
             env=self._worker_env,
         )
+        stderr_file.close()  # child has its own fd now; safe to close our handle
 
         # Send init config — include float16 flag so worker can optimise for GPU
         init_msg = (
@@ -156,8 +167,11 @@ class AvatarAnimator:
         proc.stdin.write(init_msg.encode())
         await proc.stdin.drain()
 
-        # Wait for READY — GPU loads much faster (~60s) vs CPU (~5-10 min first time)
-        model_load_timeout = 120 if self.device == "cuda" else 600
+        # Wait for READY — GPU loads much faster (~60s) vs CPU (~5-10 min first time).
+        # Bumped from 120s: cold-cache disk I/O for ~8.8GB of weights (UNet, VAE,
+        # Whisper, BiSeNet) right after a fresh worker spawn was measured timing
+        # out at 120s on this machine even on GPU.
+        model_load_timeout = 300 if self.device == "cuda" else 600
         logger.info(f"Waiting for worker to finish loading models (timeout={model_load_timeout}s)…")
         try:
             ready_line = await asyncio.wait_for(proc.stdout.readline(), timeout=model_load_timeout)
@@ -166,10 +180,10 @@ class AvatarAnimator:
             raise RuntimeError("MuseTalk worker timed out while loading models")
 
         if not ready_line.decode().strip().startswith("READY"):
-            stderr_out = await proc.stderr.read()
             proc.kill()
+            stderr_out = self._worker_stderr_path.read_text(errors="replace")[-4000:]
             raise RuntimeError(
-                f"Worker failed to start. stderr:\n{stderr_out.decode(errors='replace')}"
+                f"Worker failed to start. stderr (tail):\n{stderr_out}"
             )
 
         logger.info("MuseTalk worker ready — models loaded")

--- a/backend/app/services/tts.py
+++ b/backend/app/services/tts.py
@@ -85,6 +85,7 @@ class TTSService:
             provider = _LEGACY_PROVIDER_ALIASES[provider]
         self.provider = provider
         self.model = None
+        self._init_lock = asyncio.Lock()
 
     def _check_cuda(self) -> bool:
         try:
@@ -93,26 +94,37 @@ class TTSService:
             return False
 
     async def initialize(self):
-        """Load the Chatterbox model (downloaded from HuggingFace on first run)."""
+        """Load the Chatterbox model (downloaded from HuggingFace on first run).
+
+        Guarded by a lock — without it, concurrent WebSocket sessions each
+        call initialize() before the first one finishes, and they all race
+        to download/load the same multi-GB model at once, fighting over the
+        same HuggingFace cache lock files (worse on Windows, where the cache
+        already runs in degraded no-symlink mode).
+        """
         if self.model is not None:
             return
 
-        if self.provider != "chatterbox":
-            raise ValueError(f"Unsupported TTS provider: {self.provider}")
+        async with self._init_lock:
+            if self.model is not None:  # re-check: another coroutine may have just finished
+                return
 
-        try:
-            from chatterbox.mtl_tts import ChatterboxMultilingualTTS
+            if self.provider != "chatterbox":
+                raise ValueError(f"Unsupported TTS provider: {self.provider}")
 
-            device = "cuda" if self._check_cuda() else "cpu"
-            logger.info(f"Loading Chatterbox multilingual TTS on {device}...")
-            self.model = await asyncio.to_thread(
-                ChatterboxMultilingualTTS.from_pretrained, device=device
-            )
-            logger.info(f"Chatterbox loaded (sr={self.model.sr}, device={device})")
+            try:
+                from chatterbox.mtl_tts import ChatterboxMultilingualTTS
 
-        except Exception as e:
-            logger.error(f"Failed to load Chatterbox: {e}")
-            raise
+                device = "cuda" if self._check_cuda() else "cpu"
+                logger.info(f"Loading Chatterbox multilingual TTS on {device}...")
+                self.model = await asyncio.to_thread(
+                    ChatterboxMultilingualTTS.from_pretrained, device=device
+                )
+                logger.info(f"Chatterbox loaded (sr={self.model.sr}, device={device})")
+
+            except Exception as e:
+                logger.error(f"Failed to load Chatterbox: {e}")
+                raise
 
     async def synthesize(
         self,

--- a/frontend/components/ChatInterface.tsx
+++ b/frontend/components/ChatInterface.tsx
@@ -245,14 +245,24 @@ export function ChatInterface({ avatarId, voiceId, resumeSessionId, onSessionCre
     isPlayingRef.current = true
     setShowVideo(true)
     if (videoRef.current) {
-      videoRef.current.src = next.url
-      videoRef.current.muted = isMuted
-      // A rejected play() (autoplay policy, decode error) must not strand the
-      // queue — skip to the next chunk so playback can't hang on one bad clip.
-      videoRef.current.play().catch(() => {
-        if (chunkQueueRef.current.length > 0) playNextChunk()
-        else { isPlayingRef.current = false; setShowVideo(false) }
-      })
+      const video = videoRef.current
+      video.src = next.url
+      // Always START muted — browsers always allow muted autoplay, even
+      // outside a user gesture. Starting unmuted gets silently rejected by
+      // Chrome/Edge once the LLM+TTS+animation pipeline (several seconds) has
+      // eaten the brief post-gesture window that permits unmuted autoplay —
+      // which would needlessly skip this clip via the catch below. Unmuting an
+      // element that's ALREADY playing needs no fresh gesture, so we restore
+      // the user's mute choice right after play() resolves.
+      video.muted = true
+      video.play()
+        .then(() => { video.muted = isMuted })
+        // A rejected play() (decode error, bad clip) must not strand the
+        // queue — skip to the next chunk so playback can't hang on one bad clip.
+        .catch(() => {
+          if (chunkQueueRef.current.length > 0) playNextChunk()
+          else { isPlayingRef.current = false; setShowVideo(false) }
+        })
     }
     // Preload the next chunk in queue (if any)
     const upcoming = chunkQueueRef.current[0]
@@ -460,8 +470,15 @@ export function ChatInterface({ avatarId, voiceId, resumeSessionId, onSessionCre
         break
 
       case 'status':
-        setIsProcessing(true)
-        setStatusMsg(data.message || 'Processing…')
+        // The backend sends an "Animating…" status before EVERY sentence
+        // chunk, not just the first. Once a chunk has already started playing,
+        // re-showing the full-screen spinner on every subsequent chunk just
+        // covers the video that's still going — the user sees the spinner
+        // "stuck" and never the avatar. Only block the view pre-first-chunk.
+        if (!isPlayingRef.current) {
+          setIsProcessing(true)
+          setStatusMsg(data.message || 'Processing…')
+        }
         break
 
       case 'error':

--- a/frontend/components/providers/QueryProvider.tsx
+++ b/frontend/components/providers/QueryProvider.tsx
@@ -3,6 +3,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
 import { initWebVitals } from '@/lib/vitals'
+import { useStore } from '@/store/useStore'
 
 export function QueryProvider({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(() => new QueryClient({
@@ -16,6 +17,11 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
 
   // Boot Core Web Vitals observers once after hydration.
   useEffect(() => { initWebVitals() }, [])
+
+  // useStore has skipHydration:true (see store/useStore.ts) — pull in the
+  // persisted theme/auth/session state ourselves, but only after the first
+  // client render has matched the server's, so there's no hydration mismatch.
+  useEffect(() => { useStore.persist.rehydrate() }, [])
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/frontend/store/useStore.ts
+++ b/frontend/store/useStore.ts
@@ -66,6 +66,15 @@ export const useStore = create<AppState>()(
     }),
     {
       name: 'avatar-system-storage',
+      // Don't auto-rehydrate from localStorage during client module init —
+      // that happens synchronously, BEFORE React's first client render, so
+      // if a persisted value (e.g. theme) differs from the default used in
+      // the server-rendered HTML, the client's first render mismatches it
+      // and React throws "Hydration failed". Rehydrating manually after
+      // mount (see Providers component) means the first client render
+      // matches the server, and the persisted value applies in a normal
+      // post-hydration update instead.
+      skipHydration: true,
       partialize: (state) => ({
         token: state.token,
         user: state.user,


### PR DESCRIPTION
Builds on the recent worker/playback hardening (#5 + temp-dir/video fixes) rather than replacing it — these address failure modes still present afterward. Rebased on current `main`; backend byte-compiles and `tsc --noEmit` is clean.

- **MuseTalk worker startup deadlock:** the worker is spawned with `stderr=PIPE` that nobody drains. Loading ~8.8 GB of weights emits enough stderr (tqdm/HF bars, warnings) to fill the OS pipe buffer, after which the worker blocks forever on its next write and startup times out. Distinct from the existing BrokenPipe/EOF recovery, which never fires here because the process is alive but wedged. Fix: redirect worker stderr to a log file (read its tail on failure); raise the GPU load timeout 120 s → 300 s for cold weight I/O.
- **Muted autoplay:** start each chunk muted, then unmute once `play()` resolves. Unmuted autoplay is rejected after the multi-second LLM+TTS+animation delay, which previously sent the clip down the skip-on-failure path (dropping video + audio). Starting muted keeps autoplay allowed; the skip path now only fires on genuine errors.
- **Spinner:** don't re-show the full-screen spinner on the per-chunk "Animating…" status once playback has started — it covers the video.
- **TTS init lock:** guard model `initialize()` with an asyncio lock so concurrent sessions don't race to load the same multi-GB Chatterbox model.
- **Hydration:** `skipHydration` + `rehydrate()` after mount to avoid a React hydration mismatch when a persisted value differs from the SSR default.
