### PR TITLE
feat(llm): support Ollama cloud reasoning models via LLM_REASONING_EFFORT

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -62,6 +62,13 @@ class Settings(BaseSettings):
     LLM_MODEL: str = "claude-sonnet-4-6"
     LLM_TEMPERATURE: float = 0.7
     LLM_MAX_TOKENS: int = 2000
+    # For OpenAI-compatible reasoning ("thinking") models — notably Ollama
+    # cloud models like glm-*:cloud / kimi-*:cloud — set to "none" to disable
+    # the reasoning phase. Without it those models emit their text as
+    # `reasoning` and leave `content` empty, so the real-time pipeline gets
+    # nothing. Forwarded verbatim in the request body; leave empty for normal
+    # (non-reasoning) models so nothing is sent.
+    LLM_REASONING_EFFORT: str = ""
 
     # Avatar Engine
     AVATAR_ENGINE: str = "musetalk"  # musetalk, simple

--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -105,6 +105,10 @@ class LLMService:
         self.model = settings.LLM_MODEL
         self.temperature = settings.LLM_TEMPERATURE
         self.max_tokens = settings.LLM_MAX_TOKENS
+        # Opt-in reasoning cap for OpenAI-compatible "thinking" models (e.g.
+        # Ollama cloud glm-*:cloud / kimi-*:cloud). "none" disables reasoning
+        # so they return normal `content`. Empty → not sent (default behavior).
+        self.reasoning_effort = settings.LLM_REASONING_EFFORT or None
 
         if self.provider == "anthropic":
             self.client = anthropic.AsyncAnthropic(api_key=settings.ANTHROPIC_API_KEY)
@@ -180,6 +184,18 @@ class LLMService:
 
         raise LLMError("Anthropic response contained no text block")
 
+    def _openai_extra(self) -> dict:
+        """Extra request params for the OpenAI-compatible path.
+
+        `reasoning_effort` is forwarded via `extra_body` (not a named kwarg) so
+        it lands in the raw request body regardless of SDK version and is a
+        no-op for servers that ignore it. Needed for Ollama cloud thinking
+        models — see LLM_REASONING_EFFORT.
+        """
+        if self.reasoning_effort:
+            return {"extra_body": {"reasoning_effort": self.reasoning_effort}}
+        return {}
+
     async def _generate_openai(
         self,
         messages: List[Dict[str, str]],
@@ -194,6 +210,7 @@ class LLMService:
                 messages=messages,
                 temperature=self.temperature,
                 max_tokens=self.max_tokens,
+                **self._openai_extra(),
             )
         except Exception as e:
             mapped = _map_openai_exception(e)
@@ -253,6 +270,7 @@ class LLMService:
                 temperature=self.temperature,
                 max_tokens=self.max_tokens,
                 stream=True,
+                **self._openai_extra(),
             )
             async for chunk in stream:
                 content = chunk.choices[0].delta.content


### PR DESCRIPTION
Ollama cloud models (`glm-*:cloud`, `kimi-*:cloud`, deepseek-r1, …) are reasoning models: over the OpenAI-compatible `/v1` endpoint they emit their text as `reasoning` and leave `content` empty, so the streaming chat pipeline receives nothing and the avatar stays silent.

Adds an opt-in `LLM_REASONING_EFFORT` setting, forwarded verbatim via `extra_body` on both the streaming and non-streaming OpenAI-compatible calls. Setting it to `none` disables the reasoning phase so these models return normal content (and without the reasoning delay, which suits a real-time avatar). Empty by default → nothing sent, so OpenAI/Anthropic and local non-reasoning models are unaffected.
