### PR TITLE
fix(docker): tolerate flaky pip installs and bump frontend to Node 20

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,11 +24,11 @@ RUN apt-get update && apt-get install -y \
 # Copy requirements
 COPY requirements.txt .
 
-# Install Python dependencies
-RUN pip install --no-cache-dir -r requirements.txt
+# Install Python dependencies (retries/timeout tolerate an unstable connection)
+RUN pip install --no-cache-dir --retries 10 --timeout 100 -r requirements.txt
 
 # Install PyTorch with CUDA 11.8 (matches base image)
-RUN pip install --no-cache-dir \
+RUN pip install --no-cache-dir --retries 10 --timeout 100 \
     torch==2.2.0+cu118 \
     torchvision==0.17.0+cu118 \
     torchaudio==2.2.0+cu118 \

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -32,9 +32,7 @@ python-socketio==5.11.0
 # and the cache_control parameter used in app/services/llm.py
 anthropic>=0.45.0
 openai>=1.50.0
-torch==2.2.0
-torchvision==0.17.0
-torchaudio==2.2.0
+# torch/torchvision/torchaudio installed separately in Dockerfile (+cu118 build)
 transformers==4.37.2
 accelerate==0.26.1
 diffusers==0.32.2

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:20-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Add `--retries`/`--timeout` to backend pip installs so an unstable connection does not fail the build
- Drop redundant CPU torch pins from `requirements.txt` (CUDA build is installed separately in the Dockerfile)
- Bump frontend base image to `node:20-alpine` to satisfy Next 16's minimum Node requirement

## Test plan
- [ ] Build backend image and confirm pip install succeeds
- [ ] Build frontend image and confirm it builds on Node 20
